### PR TITLE
CMake: Link libgcc and libstdc++ statically on g++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ set_property(TARGET sp PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET libspawner PROPERTY CXX_STANDARD 11)
 set_property(TARGET libspawner PROPERTY CXX_STANDARD_REQUIRED ON)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-static-libgcc -static-libstdc++ ${CMAKE_CXX_FLAGS}")
+endif()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "--stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 endif()

--- a/libspawner/CMakeLists.txt
+++ b/libspawner/CMakeLists.txt
@@ -122,6 +122,10 @@ add_library(${PROJECT_LIBRARY} ${SOURCES} ${HEADERS})
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7")
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-static-libgcc -static-libstdc++ ${CMAKE_CXX_FLAGS}")
+endif()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "--stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 endif()


### PR DESCRIPTION
This should fix issues like that:
https://travis-ci.org/klenin/cats-judge/jobs/200629025