### PR TITLE
Windows: Handle CreateProcess() fail due to extra large stack.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(SOURCES
 set(LIBRARIES "libspawner")
 
 if(WIN32)
-    set(LIBRARIES ${LIBRARIES} "userenv")
+    set(LIBRARIES ${LIBRARIES} "userenv" "imagehlp")
     add_definitions(-DWINVER=0x0501 -D_WIN32_WINNT=WINVER)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,10 @@ set(SOURCES
     src/spawner_pcms2.cpp
 )
 
-set(LIBRARIES libspawner)
+set(LIBRARIES "libspawner")
 
 if(WIN32)
-    find_library(USERENV userenv)
-    if(USERENV)
-        set(LIBRARIES ${LIBRARIES} ${USERENV})
-    endif()
+    set(LIBRARIES ${LIBRARIES} "userenv")
     add_definitions(-DWINVER=0x0501 -D_WIN32_WINNT=WINVER)
 endif()
 

--- a/libspawner/inc/base_runner.h
+++ b/libspawner/inc/base_runner.h
@@ -20,7 +20,7 @@ protected:
     report_class report;
     options_class options;
     process_status_t process_status = process_not_started;
-    unsigned long long int creation_time;
+    unsigned long long int creation_time = 0;
     std::string program;
 public:
     multipipe_ptr get_pipe(const std_stream_type &stream_type);

--- a/libspawner/inc/base_runner.h
+++ b/libspawner/inc/base_runner.h
@@ -8,7 +8,7 @@
 #include "inc/status.h"
 #include "inc/multibyte.h"
 #include "inc/multipipe.h"
-
+#include "inc/report.h"
 #include "platform_report.h"
 
 class base_runner {
@@ -20,6 +20,7 @@ protected:
     report_class report;
     options_class options;
     process_status_t process_status = process_not_started;
+    terminate_reason_t terminate_reason = terminate_reason_not_terminated;
     unsigned long long int creation_time = 0;
     std::string program;
 public:

--- a/libspawner/inc/win32/runner.h
+++ b/libspawner/inc/win32/runner.h
@@ -45,6 +45,7 @@ public:
     virtual ~runner();
     unsigned long get_exit_code();
     virtual process_status_t get_process_status();
+    terminate_reason_t get_terminate_reason();
     process_status_t get_process_status_no_side_effects();
     exception_t get_exception();
     unsigned long get_id();

--- a/libspawner/inc/win32/runner.h
+++ b/libspawner/inc/win32/runner.h
@@ -20,6 +20,9 @@ private:
     env_vars_list_t read_environment(const WCHAR* source) const;
     env_vars_list_t set_environment_for_process() const;
     void restore_original_environment(const env_vars_list_t& original) const;
+
+    bool program_stack_exceeds_1gb();
+    bool try_handle_createproc_error();
     mutex_c suspend_mutex_;
 protected:
     DWORD process_creation_flags;

--- a/libspawner/inc/win32/securerunner.h
+++ b/libspawner/inc/win32/securerunner.h
@@ -14,7 +14,6 @@ protected:
     restrictions_class start_restrictions;
     restrictions_class restrictions;
     thread_t check_thread;
-    terminate_reason_t terminate_reason;
     std::atomic<bool> prolong_time_limits_{false};
     LONGLONG base_time_processor_ = 0;
     unsigned long long base_time_user_ = 0;
@@ -32,8 +31,6 @@ public:
     secure_runner(const std::string &program, const options_class &options,
         const restrictions_class &restrictions);
     virtual ~secure_runner();
-
-    terminate_reason_t get_terminate_reason();
 
     restrictions_class get_restrictions() const;
     process_status_t get_process_status();

--- a/libspawner/src/base_runner.cpp
+++ b/libspawner/src/base_runner.cpp
@@ -22,7 +22,5 @@ multipipe_ptr base_runner::get_pipe(const std_stream_type& stream_type) {
 
 base_runner::base_runner(const std::string& program, const options_class& options)
     : program(program)
-    , options(options)
-    , process_status(process_not_started)
-    , creation_time(0) {
+    , options(options) {
 }

--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -400,6 +400,10 @@ process_status_t runner::get_process_status() {
     return process_status;
 }
 
+terminate_reason_t runner::get_terminate_reason() {
+    return terminate_reason;
+}
+
 exception_t runner::get_exception() {
     if (get_process_status() == process_finished_abnormally) {
         return (exception_t)get_exit_code();
@@ -420,8 +424,9 @@ options_class runner::get_options() const {
 }
 
 report_class runner::get_report() {
+    report.process_status = get_process_status();
+    report.terminate_reason = (process_status == process_spawner_crash) ? terminate_reason_none : get_terminate_reason();
     report.application_name = get_program();
-
     report.exception = get_exception();
     report.exit_code = get_exit_code();
     return report;

--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -353,10 +353,8 @@ thread_return_t runner::async_body(thread_param_t param) {
 runner::runner(const std::string &program, const options_class &options)
     : base_runner(program, options)
     , running_thread(INVALID_HANDLE_VALUE)
-    , init_semaphore(INVALID_HANDLE_VALUE) {
-
-    init_semaphore = CreateSemaphore(NULL, 0, 10, NULL);
-    ZeroMemory(&process_info, sizeof(process_info));
+    , init_semaphore(CreateSemaphore(NULL, 0, 10, NULL))
+    , process_info() {
 }
 
 runner::~runner() {

--- a/libspawner/src/win32/securerunner.cpp
+++ b/libspawner/src/win32/securerunner.cpp
@@ -280,8 +280,7 @@ secure_runner::secure_runner(const std::string &program,
     , restrictions(restrictions)
     , hIOCP(INVALID_HANDLE_VALUE)
     , hJob(INVALID_HANDLE_VALUE)
-    , check_thread(INVALID_HANDLE_VALUE)
-    , terminate_reason(terminate_reason_not_terminated) {
+    , check_thread(INVALID_HANDLE_VALUE) {
 }
 
 secure_runner::~secure_runner()
@@ -301,16 +300,9 @@ void secure_runner::requisites()
     check_thread = CreateThread(NULL, 0, check_limits_proc, this, 0, NULL);
 }
 
-terminate_reason_t secure_runner::get_terminate_reason() {
-    return terminate_reason;
-}
-
 report_class secure_runner::get_report() {
     JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION bai;
-    report.process_status = get_process_status();
-    if (get_process_status() == process_spawner_crash) {
-        report.terminate_reason = terminate_reason_none;
-    } else if (hJob != INVALID_HANDLE_VALUE) {
+    if (hJob != INVALID_HANDLE_VALUE) {
         if (!QueryInformationJobObject(hJob, JobObjectBasicAndIoAccountingInformation, &bai, sizeof(bai), NULL)) {
             //throw GetWin32Error("QueryInformationJobObject");
         }
@@ -325,7 +317,6 @@ report_class secure_runner::get_report() {
         }
 
         report.peak_memory_used = xli.PeakJobMemoryUsed;
-        report.terminate_reason = get_terminate_reason();
     }
 
     return runner::get_report();


### PR DESCRIPTION
Now it's handled as `MemoryLimitExceeded` error.
This should close klenin/cats-judge#44.