### PR TITLE
Windows: Handle CreateProcess() fail due to extra large data segment.

### DIFF
--- a/libspawner/inc/win32/runner.h
+++ b/libspawner/inc/win32/runner.h
@@ -21,7 +21,6 @@ private:
     env_vars_list_t set_environment_for_process() const;
     void restore_original_environment(const env_vars_list_t& original) const;
 
-    bool program_stack_exceeds_1gb();
     bool try_handle_createproc_error();
     mutex_c suspend_mutex_;
 protected:

--- a/libspawner/inc/win32/runner.h
+++ b/libspawner/inc/win32/runner.h
@@ -21,7 +21,7 @@ private:
     env_vars_list_t set_environment_for_process() const;
     void restore_original_environment(const env_vars_list_t& original) const;
 
-    bool try_handle_createproc_error();
+    virtual bool try_handle_createproc_error();
     mutex_c suspend_mutex_;
 protected:
     DWORD process_creation_flags;

--- a/libspawner/inc/win32/securerunner.h
+++ b/libspawner/inc/win32/securerunner.h
@@ -8,6 +8,8 @@
 
 class secure_runner: public runner
 {
+private:
+    virtual bool try_handle_createproc_error() override;
 protected:
     handle_t hIOCP;
     handle_t hJob;

--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -139,26 +139,38 @@ void runner::restore_original_environment(const runner::env_vars_list_t& origina
     }
 }
 
-bool runner::program_stack_exceeds_1gb() {
+bool runner::try_handle_createproc_error() {
+    const DWORD error_code = GetLastError();
+    bool stackseg_excessive, dataseg_excessive;
+
     LOADED_IMAGE exe_image;
-    bool stack_exceeds_1gb = false;
-    
     char* exe_path_rw = _strdup(program.c_str());
+
     if (MapAndLoad(exe_path_rw, NULL, &exe_image, FALSE, TRUE)) {
-        stack_exceeds_1gb = 0x40000000 < exe_image.FileHeader->OptionalHeader.SizeOfStackReserve;
+        stackseg_excessive = 0x40000000 < exe_image.FileHeader->OptionalHeader.SizeOfStackReserve;
+        dataseg_excessive = 0x80000000 < exe_image.FileHeader->OptionalHeader.SizeOfUninitializedData;
         UnMapAndLoad(&exe_image);
+    } else {
+        stackseg_excessive = false;
+        dataseg_excessive = false;
     }
 
     std::free(exe_path_rw);
-    return stack_exceeds_1gb;
-}
 
-bool runner::try_handle_createproc_error() {
-    DWORD error_code = GetLastError();
+    // MapAndLoad() / UnMapAndLoad() reset Windows last error, so we restore it
+    SetLastError(error_code);
+
+    const bool stackseg_related_error =
+        (error_code == ERROR_NOT_ENOUGH_MEMORY) ||
+        (error_code == ERROR_INVALID_PARAMETER); // Windows XP specific
+
+    const bool dataseg_related_error =
+        (error_code == ERROR_INVALID_PARAMETER) ||
+        (error_code == ERROR_BAD_EXE_FORMAT);
 
     if (
-      error_code == ERROR_NOT_ENOUGH_MEMORY ||
-      (error_code == ERROR_INVALID_PARAMETER && program_stack_exceeds_1gb()) // Windows XP specific
+      (stackseg_related_error && stackseg_excessive) ||
+      (dataseg_related_error && dataseg_excessive)
     ) {
         terminate_reason = terminate_reason_memory_limit;
         return true;


### PR DESCRIPTION
Now it's handled as `MemoryLimitExceeded` error.
This should close klenin/cats-judge#45.