### PR TITLE
Use C++11 range-based for-loop syntax where possible.

### DIFF
--- a/libspawner/src/multipipe.cpp
+++ b/libspawner/src/multipipe.cpp
@@ -29,7 +29,7 @@ multipipe::multipipe(system_pipe_ptr pipe, int bsize, pipe_mode mode, bool autos
 
 void multipipe::set_new_line_checking() {
     check_new_line = false;
-    for (auto &sink: sinks) {
+    for (const auto& sink : sinks) {
         if (auto p = sink.second.lock()) {
             if (!p->get_pipe()->is_file() || p->parents_count > 1) {
                 check_new_line = true;
@@ -87,7 +87,7 @@ void multipipe::write(const char* bytes, size_t count, set<int>& src) {
     write_mutex.lock();
 
     src.insert(id);
-    for (auto& pipe : sinks) {
+    for (const auto& pipe : sinks) {
         PANIC_IF(src.find(pipe.first) != src.end());
         if (auto p = pipe.second.lock()) {
             p->write(bytes, count, src);
@@ -104,7 +104,7 @@ void multipipe::close_and_notify() {
     flush();
 
     auto childs = this->sinks;
-    for (auto& pipe : childs)
+    for (const auto& pipe : childs)
         disconnect(pipe.second);
 
     core_pipe->close();

--- a/libspawner/src/options.cpp
+++ b/libspawner/src/options.cpp
@@ -26,17 +26,17 @@ options_class::options_class(const options_class &options)
     , monitorInterval(options.monitorInterval)
     , report_file(options.report_file) {
 
-    for (auto i = options.stdinput.begin(); i != options.stdinput.end(); ++i) {
-        stdinput.push_back(*i);
+    for (const auto& i : options.stdinput) {
+        stdinput.push_back(i);
     }
-    for (auto i = options.stdoutput.begin(); i != options.stdoutput.end(); ++i) {
-        stdoutput.push_back(*i);
+    for (const auto& i : options.stdoutput) {
+        stdoutput.push_back(i);
     }
-    for (auto i = options.stderror.begin(); i != options.stderror.end(); ++i) {
-        stderror.push_back(*i);
+    for (const auto& i : options.stderror) {
+        stderror.push_back(i);
     }
-    for (auto i = options.arguments.begin(); i != options.arguments.end(); ++i) {
-        arguments.push_back(*i);
+    for (const auto& i : options.arguments) {
+        arguments.push_back(i);
     }
 
     environmentVars = options.environmentVars;
@@ -48,8 +48,8 @@ void options_class::add_argument(std::string argument) {
 }
 
 void options_class::add_arguments(const std::vector<std::string> &arguments_a) {
-    for (size_t i = 0; i < arguments_a.size(); ++i) {
-        arguments.push_back(arguments_a[i]);
+    for (const auto& i : arguments_a) {
+        arguments.push_back(i);
     }
 }
 

--- a/libspawner/src/posix/delegate.cpp
+++ b/libspawner/src/posix/delegate.cpp
@@ -76,9 +76,9 @@ void delegate_runner::create_process() {
     }
 
     auto process_pipes = [](options_class& options, const std::vector<std::string>& vals, const std::string& prefix) {
-        for (auto i = vals.cbegin(); i != vals.cend(); ++i)
+        for (const auto& i : vals)
         {
-            options.push_argument_front(prefix + *i);
+            options.push_argument_front(prefix + i);
         }
     };
 
@@ -104,9 +104,9 @@ void delegate_runner::create_process() {
         options.push_argument_front("-hr=1");
     }
 
-    for (auto i = options.environmentVars.cbegin(); i != options.environmentVars.cend(); ++i)
+    for (const auto& i : options.environmentVars)
     {
-        options.push_argument_front("-D " + i->first + "=" + i->second);
+        options.push_argument_front("-D " + i.first + "=" + i.second);
     }
 
     if (options.json)

--- a/libspawner/src/posix/runner.cpp
+++ b/libspawner/src/posix/runner.cpp
@@ -58,15 +58,15 @@ char **runner::create_envp_for_process() const
         PANIC("user-default mode is not supported");
         //setenv("SPAWNER_VERSION", "POSIX", 1);
         } else if (options.environmentMode == "clear")
-        for (auto i = curr_vars.cbegin(); i != curr_vars.cend(); ++i)
+        for (const auto& i : curr_vars)
             // use unsetenv() or leave environ pointer with nullptr
-            setenv(i->first.c_str(), "" , 1);
+            setenv(i.first.c_str(), "" , 1);
         else if (options.environmentMode == "inherit")
-        for (auto i = curr_vars.cbegin(); i != curr_vars.cend(); ++i)
-            setenv(i->first.c_str(), i->second.c_str(), 1);
+        for (const auto& i : curr_vars)
+            setenv(i.first.c_str(), i.second.c_str(), 1);
 
-        for (auto i = options.environmentVars.cbegin(); i != options.environmentVars.cend(); ++i)
-            setenv(i->first.c_str(), i->second.c_str(), 1);
+        for (const auto& i : options.environmentVars)
+            setenv(i.first.c_str(), i.second.c_str(), 1);
 
 
     // restore original environ pointer

--- a/libspawner/src/posix/runner.cpp
+++ b/libspawner/src/posix/runner.cpp
@@ -57,17 +57,17 @@ char **runner::create_envp_for_process() const
     if (options.environmentMode == "user-default") {
         PANIC("user-default mode is not supported");
         //setenv("SPAWNER_VERSION", "POSIX", 1);
-        } else if (options.environmentMode == "clear")
+    } else if (options.environmentMode == "clear") {
         for (const auto& i : curr_vars)
             // use unsetenv() or leave environ pointer with nullptr
             setenv(i.first.c_str(), "" , 1);
-        else if (options.environmentMode == "inherit")
+    } else if (options.environmentMode == "inherit") {
         for (const auto& i : curr_vars)
             setenv(i.first.c_str(), i.second.c_str(), 1);
+    }
 
-        for (const auto& i : options.environmentVars)
-            setenv(i.first.c_str(), i.second.c_str(), 1);
-
+    for (const auto& i : options.environmentVars)
+        setenv(i.first.c_str(), i.second.c_str(), 1);
 
     // restore original environ pointer
     result = environ;

--- a/libspawner/src/win32/delegate.cpp
+++ b/libspawner/src/win32/delegate.cpp
@@ -70,9 +70,9 @@ void delegate_runner::create_process() {
     }
 
     auto process_pipes = [](options_class& options, const std::vector<std::string>& vals, const std::string& prefix) {
-        for (auto i = vals.cbegin(); i != vals.cend(); ++i)
+        for (const auto& i : vals)
         {
-            options.push_argument_front(prefix + *i);
+            options.push_argument_front(prefix + i);
         }
     };
 
@@ -98,9 +98,9 @@ void delegate_runner::create_process() {
         options.push_argument_front("-hr 1");
     }
 
-    for (auto i = options.environmentVars.cbegin(); i != options.environmentVars.cend(); ++i)
+    for (const auto& i : options.environmentVars)
     {
-        options.push_argument_front("-D " + i->first + "=" + i->second);
+        options.push_argument_front("-D " + i.first + "=" + i.second);
     }
 
     if (options.json)

--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -88,29 +88,29 @@ runner::env_vars_list_t runner::set_environment_for_process() const
 
         DestroyEnvironmentBlock(envBlock);
 
-        for (auto i = default_vars.cbegin(); i != default_vars.cend(); ++i)
+        for (const auto& i : default_vars)
         {
-            SetEnvironmentVariableA(i->first.c_str(), i->second.c_str());
+            SetEnvironmentVariableA(i.first.c_str(), i.second.c_str());
         }
 
-        for (auto i = curr_vars.cbegin(); i != curr_vars.cend(); ++i)
+        for (const auto& i : curr_vars)
         {
-            if (std::find(default_vars.cbegin(), default_vars.cend(), *i) == default_vars.cend())
+            if (std::find(default_vars.cbegin(), default_vars.cend(), i) == default_vars.cend())
             {
-                SetEnvironmentVariableA(i->first.c_str(), nullptr);
+                SetEnvironmentVariableA(i.first.c_str(), nullptr);
             }
         }
     }
     else if (options.environmentMode == "clear")
     {
-        for (auto i = curr_vars.cbegin(); i != curr_vars.cend(); ++i)
+        for (const auto& i : curr_vars)
         {
-            SetEnvironmentVariableA(i->first.c_str(), nullptr);
+            SetEnvironmentVariableA(i.first.c_str(), nullptr);
         }
     }
 
-    for (auto i = options.environmentVars.cbegin(); i != options.environmentVars.cend(); ++i) {
-        SetEnvironmentVariableA(i->first.c_str(), i->second.c_str());
+    for (const auto& i : options.environmentVars) {
+        SetEnvironmentVariableA(i.first.c_str(), i.second.c_str());
     }
 
     return curr_vars;
@@ -120,16 +120,16 @@ void runner::restore_original_environment(const runner::env_vars_list_t& origina
 {
     auto curr_vars = read_environment(GetEnvironmentStringsW());
 
-    for (auto i = original.cbegin(); i != original.cend(); ++i)
+    for (const auto& i : original)
     {
-        SetEnvironmentVariableA(i->first.c_str(), i->second.c_str());
+        SetEnvironmentVariableA(i.first.c_str(), i.second.c_str());
     }
 
-    for (auto i = curr_vars.cbegin(); i != curr_vars.cend(); ++i)
+    for (const auto& i : curr_vars)
     {
-        if (std::find(original.cbegin(), original.cend(), *i) == original.cend())
+        if (std::find(original.cbegin(), original.cend(), i) == original.cend())
         {
-            SetEnvironmentVariableA(i->first.c_str(), nullptr);
+            SetEnvironmentVariableA(i.first.c_str(), nullptr);
         }
     }
 }
@@ -286,8 +286,8 @@ void runner::create_process() {
     if (!options.string_arguments.empty()) {
         command_line += " " + options.string_arguments;
     }
-    for (auto arg = options.arguments.begin(); arg != options.arguments.end(); ++arg) {
-        command_line += " " + quote(*arg);
+    for (const auto& arg : options.arguments) {
+        command_line += " " + quote(arg);
     }
 
     if (!options.login.empty()) {

--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -491,7 +491,7 @@ void runner::run_process() {
         }
     }
 
-    for (auto& stream : streams) {
+    for (const auto& stream : streams) {
         stream.second->finalize();
     }
 }

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -273,8 +273,8 @@ std::string console_argument_parser_c::help(const abstract_settings_parser_c &pa
     }
     for (auto i : parsers) {
         //iterating over all arguments
-        for (auto j = i.second.begin(); j != i.second.end(); ++j) {
-            if (j != i.second.begin()) {
+        for (auto j = i.second.cbegin(); j != i.second.cend(); ++j) {
+            if (j != i.second.cbegin()) {
                 res << ", ";
             }
             if (*j == SEPARATOR_ARGUMENT) {
@@ -321,8 +321,8 @@ std::string environment_variable_parser_c::help(abstract_settings_parser_c *pars
     std::ostringstream res;
     for (auto i : parsers) {
         //iterating over all arguments
-        for (auto j = i.second.begin(); j != i.second.end(); ++j) {
-            if (j != i.second.begin()) {
+        for (auto j = i.second.cbegin(); j != i.second.cend(); ++j) {
+            if (j != i.second.cbegin()) {
                 res << ", ";
             }
             res << *j << "=" << i.first->value_description();

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -32,14 +32,14 @@ compact_list_c::operator std::vector<std::string>() const {
 }
 
 abstract_parser_c::~abstract_parser_c() {
-    for (auto i = parameters.begin(); i != parameters.end(); i++) {
-        i->second->dereference();
+    for (const auto& i : parameters) {
+        i.second->dereference();
     }
 }
 
 abstract_argument_parser_c *abstract_parser_c::add_argument_parser(const std::vector<std::string> &params, abstract_argument_parser_c *argument_parser) {
-    for (auto i = params.begin(); i != params.end(); ++i) {
-        parameters[*i] = argument_parser->reference();
+    for (const auto& i : params) {
+        parameters[i] = argument_parser->reference();
     }
     parsers[argument_parser] = params;
     return argument_parser;
@@ -103,8 +103,8 @@ abstract_parser_c *settings_parser_c::pop_saved_parser() {
     return value.second;
 }
 void settings_parser_c::clear_parsers() {
-    for (auto i = parsers.begin(); i != parsers.end(); ++i) {
-        delete (*i);
+    for (auto p : parsers) {
+        delete p;
     }
     parsers.clear();
 }
@@ -130,15 +130,15 @@ bool settings_parser_c::parse(int argc, char *argv[]) {
     arg_c = argc;
     arg_v = argv;
     position = 1;
-    for (size_t i = 0; i < parsers.size(); ++i) {
-        parsers[i]->invoke_initialization(*this);
+    for (auto p : parsers) {
+        p->invoke_initialization(*this);
     }
 
     while (current_position() < argc && !stopped) {
-        for (auto parser = parsers.begin(); parser != parsers.end(); ++parser) {
+        for (auto parser : parsers) {
             int fetched_position = position;
-            if ((*parser)->parse(*this)) {
-                save_current_position(*parser);
+            if (parser->parse(*this)) {
+                save_current_position(parser);
             }
             position = fetched_position;
         }
@@ -180,8 +180,8 @@ void settings_parser_c::pop_back() {
 
 std::string settings_parser_c::help() {
     std::string result;
-    for (auto parser = parsers.begin(); parser != parsers.end(); ++parser) {
-        result += (*parser)->help(*this);
+    for (auto parser : parsers) {
+        result += parser->help(*this);
     }
     return result;
 }
@@ -203,8 +203,8 @@ bool console_argument_parser_c::parse(abstract_settings_parser_c &parser_object)
     return last_state == argument_ok_state;
 }
 abstract_argument_parser_c *console_argument_parser_c::add_flag_parser(const std::vector<std::string> &params, abstract_argument_parser_c *argument_parser) {
-    for (auto i = params.begin(); i != params.end(); ++i) {
-        is_flag[*i] = true;
+    for (const auto& i : params) {
+        is_flag[i] = true;
     }
     return add_argument_parser(params, argument_parser);
 }
@@ -223,11 +223,11 @@ console_argument_parser_c::parsing_state_e console_argument_parser_c::process_ar
     }
     size_t length = s.length();
     size_t divider_length = 0;
-    for (auto i = parser_object->dividers.begin(); i != parser_object->dividers.end(); ++i) {
-        size_t pos = s.find(*i);
+    for (const auto& i : parser_object->dividers) {
+        size_t pos = s.find(i);
         length = min_def(length, pos);
         if (length == pos) {
-            divider_length = max_def(divider_length, (*i).length());
+            divider_length = max_def(divider_length, i.length());
         }
     }
     left = s.substr(0, length);
@@ -271,10 +271,10 @@ std::string console_argument_parser_c::help(const abstract_settings_parser_c &pa
     if (parser.dividers.size()) {
         dividers = parser.dividers[0];
     }
-    for (auto i = parsers.begin(); i != parsers.end(); i++) {
+    for (auto i : parsers) {
         //iterating over all arguments
-        for (auto j = i->second.begin(); j != i->second.end(); j++) {
-            if (j != i->second.begin()) {
+        for (auto j = i.second.begin(); j != i.second.end(); ++j) {
+            if (j != i.second.begin()) {
                 res << ", ";
             }
             if (*j == SEPARATOR_ARGUMENT) {
@@ -283,10 +283,10 @@ std::string console_argument_parser_c::help(const abstract_settings_parser_c &pa
                 res << *j;
             }
             if (!is_flag[*j]) {
-                res << dividers << i->first->value_description();
+                res << dividers << i.first->value_description();
             }
         }
-        res << std::endl << "\t" << i->first->description() << std::endl;
+        res << std::endl << "\t" << i.first->description() << std::endl;
     }
     return res.str();
 }
@@ -300,16 +300,16 @@ bool environment_variable_parser_c::invoke_initialization(abstract_settings_pars
         return true;
     }
 
-    for (auto i = parameters.begin(); i != parameters.end(); i++) {
-        auto result = get_env_var(i->first.c_str(), buffer, sizeof(buffer));
+    for (const auto& i : parameters) {
+        auto result = get_env_var(i.first.c_str(), buffer, sizeof(buffer));
 
         if (result > sizeof(buffer)) {
-            std::cerr << "Invalid parameter value for \"" << i->first << "\" with error: Buffer overflow" << std::endl;
+            std::cerr << "Invalid parameter value for \"" << i.first << "\" with error: Buffer overflow" << std::endl;
         } else if (result > 0) {
             try {
-                i->second->apply(std::string(buffer, result));
+                i.second->apply(std::string(buffer, result));
             } catch (std::string &error) {
-                std::cerr << "Invalid parameter value for \"" << i->first << "\" with error: " << error << std::endl;
+                std::cerr << "Invalid parameter value for \"" << i.first << "\" with error: " << error << std::endl;
             }
         }
     }
@@ -319,15 +319,15 @@ bool environment_variable_parser_c::invoke_initialization(abstract_settings_pars
 
 std::string environment_variable_parser_c::help(abstract_settings_parser_c *parser) {
     std::ostringstream res;
-    for (auto i = parsers.begin(); i != parsers.end(); i++) {
+    for (auto i : parsers) {
         //iterating over all arguments
-        for (auto j = i->second.begin(); j != i->second.end(); j++) {
-            if (j != i->second.begin()) {
+        for (auto j = i.second.begin(); j != i.second.end(); ++j) {
+            if (j != i.second.begin()) {
                 res << ", ";
             }
-            res << *j << "=" << i->first->value_description();
+            res << *j << "=" << i.first->value_description();
         }
-        res << std::endl << "\t" << i->first->description() << std::endl;
+        res << std::endl << "\t" << i.first->description() << std::endl;
     }
     return res.str();
 }

--- a/src/spawner_new.cpp
+++ b/src/spawner_new.cpp
@@ -147,7 +147,7 @@ void spawner_new_c::json_report(runner *runner_instance,
     writer.StartArray();
     std::vector<std::string> errors;
     errors.push_back(get_error_text());
-    for (auto& error : errors) {
+    for (const auto& error : errors) {
         rapidjson_write(error.c_str());
     }
     writer.EndArray();
@@ -350,7 +350,7 @@ bool spawner_new_c::init() {
 
     for (auto runner : runners) {
         options_class runner_options = runner->get_options();
-        struct {
+        const struct {
             std::vector<std::string> &streams;
             std_stream_type type;
         } streams[] = {
@@ -358,8 +358,8 @@ bool spawner_new_c::init() {
             { runner_options.stdoutput, std_stream_output },
             { runner_options.stderror, std_stream_error },
         };
-        for (auto& stream_item : streams) {
-            for (auto& stream_str : stream_item.streams) {
+        for (const auto& stream_item : streams) {
+            for (const auto& stream_str : stream_item.streams) {
                 PANIC_IF(stream_str.size() == 0);
                 if (stream_str[0] != '*') {
                     continue;
@@ -421,7 +421,7 @@ void spawner_new_c::run() {
     for (auto i : runners) {
         i->run_process_async();
     }
-    for (auto& file_pipe : file_pipes) {
+    for (const auto& file_pipe : file_pipes) {
         file_pipe.second->start_read();
     }
     for (auto i : runners) {

--- a/src/spawner_new.cpp
+++ b/src/spawner_new.cpp
@@ -116,20 +116,20 @@ void spawner_new_c::json_report(runner *runner_instance,
 
     rapidjson_write("StdOut");
     writer.StartArray();
-    for (uint i = 0; i < runner_options.stdoutput.size(); ++i) {
-        rapidjson_write(runner_options.stdoutput[i].c_str());
+    for (const auto& i : runner_options.stdoutput) {
+        rapidjson_write(i.c_str());
     }
     writer.EndArray();
     rapidjson_write("StdErr");
     writer.StartArray();
-    for (uint i = 0; i < runner_options.stderror.size(); ++i) {
-        rapidjson_write(runner_options.stderror[i].c_str());
+    for (const auto& i : runner_options.stderror) {
+        rapidjson_write(i.c_str());
     }
     writer.EndArray();
     rapidjson_write("StdIn");
     writer.StartArray();
-    for (uint i = 0; i < runner_options.stdinput.size(); ++i) {
-        rapidjson_write(runner_options.stdinput[i].c_str());
+    for (const auto& i : runner_options.stdinput) {
+        rapidjson_write(i.c_str());
     }
     writer.EndArray();
 
@@ -450,13 +450,13 @@ void spawner_new_c::print_report() {
     rapidjson::StringBuffer s;
     rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF16<> > report_writer(s);
     report_writer.StartArray();
-    for (auto i = runners.begin(); i != runners.end(); ++i) {
-        report_class rep = (*i)->get_report();
-        options_class options_item = (*i)->get_options();
+    for (auto i : runners) {
+        report_class rep = i->get_report();
+        options_class options_item = i->get_options();
         std::cout.flush();
         if (!options_item.hide_report || options_item.report_file.length()) {
             std::string report;
-            json_report(*i, report_writer);
+            json_report(i, report_writer);
 
             if (options_item.login.length() > 0)
             {
@@ -469,7 +469,7 @@ void spawner_new_c::print_report() {
                 {
                     report = GenerateSpawnerReport(
                         rep, options_item,
-                        (*i)->get_restrictions()
+                        i->get_restrictions()
                     );
                 }
                 else
@@ -477,7 +477,7 @@ void spawner_new_c::print_report() {
                     rapidjson::StringBuffer sub_report;
                     rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF16<> > report_item_writer(sub_report);
                     report_item_writer.StartArray();
-                    json_report(*i, report_item_writer);
+                    json_report(i, report_item_writer);
                     report_item_writer.EndArray();
                     report = sub_report.GetString();
                 }

--- a/src/spawner_new.cpp
+++ b/src/spawner_new.cpp
@@ -14,7 +14,7 @@ spawner_new_c::spawner_new_c(settings_parser_c &parser)
 }
 
 spawner_new_c::~spawner_new_c() {
-    for (auto& i : runners) {
+    for (auto i : runners) {
         i->wait_for();
         delete i;
     }
@@ -348,7 +348,7 @@ bool spawner_new_c::init() {
         }
     }
 
-    for (auto& runner : runners) {
+    for (auto runner : runners) {
         options_class runner_options = runner->get_options();
         struct {
             std::vector<std::string> &streams;
@@ -418,16 +418,16 @@ bool spawner_new_c::init_runner() {
 
 void spawner_new_c::run() {
     begin_report();
-    for (auto& i : runners) {
+    for (auto i : runners) {
         i->run_process_async();
     }
     for (auto& file_pipe : file_pipes) {
         file_pipe.second->start_read();
     }
-    for (auto& i : runners) {
+    for (auto i : runners) {
         i->get_pipe(std_stream_input)->check_parents();
     }
-    for (auto& i : runners) {
+    for (auto i : runners) {
         i->wait_for();
     }
     print_report();

--- a/src/spawner_old.cpp
+++ b/src/spawner_old.cpp
@@ -53,15 +53,15 @@ bool spawner_old_c::init()
             auto stdoutput = runner_instance->get_pipe(std_stream_output);
             auto stderror = runner_instance->get_pipe(std_stream_error);
 
-            for (auto& input : options.stdinput)
+            for (const auto& input : options.stdinput)
                 if (input[0] != '*')
                     get_or_create_file_pipe(input, read_mode)->connect(stdinput);
 
-            for (auto& output : options.stdoutput)
+            for (const auto& output : options.stdoutput)
                 if (output[0] != '*')
                     stdoutput->connect(get_or_create_file_pipe(output, write_mode));
 
-            for (auto& error : options.stderror)
+            for (const auto& error : options.stderror)
                 if (error[0] != '*')
                     stderror->connect(get_or_create_file_pipe(error, write_mode));
         }
@@ -71,7 +71,7 @@ bool spawner_old_c::init()
 void spawner_old_c::run() {
     begin_report();
     runner_instance->run_process_async();
-    for (auto& file_pipe : file_pipes) {
+    for (const auto& file_pipe : file_pipes) {
         file_pipe.second->start_read();
     }
     runner_instance->get_pipe(std_stream_input)->check_parents();


### PR DESCRIPTION
This also fixes unnecessary usage of references for primitive types like pointers.