### PR TITLE
Win32/runner: Fix incorrect initialization of lpDesktop.

### DIFF
--- a/libspawner/src/win32/runner.cpp
+++ b/libspawner/src/win32/runner.cpp
@@ -252,8 +252,7 @@ void runner::create_process() {
             si.hStdError = streams[std_stream_error]->get_pipe()->get_output_handle();
     }
 
-    //FIXME: C++11 forbids implicit conversion of a string constant to 'char*'
-    si.lpDesktop = "";
+    si.lpDesktop = nullptr;
 
     process_creation_flags = PROCESS_CREATION_FLAGS;
 


### PR DESCRIPTION
Separated from #68, see outdated review there for details.