### PR TITLE
posix/runner.cpp: Fix race between calls 'resume' and 'suspend'

### DIFF
--- a/libspawner/src/posix/runner.cpp
+++ b/libspawner/src/posix/runner.cpp
@@ -232,10 +232,10 @@ void runner::waitpid_body() {
             exit_code = WEXITSTATUS(status);
         } else if (WIFSTOPPED(status)) {
             LOG("stopped", get_index());
+            process_status = process_suspended;
             if (resume_requested) {
                 resume();
             }
-            process_status = process_suspended;
         } else if (WIFCONTINUED(status)) {
             LOG("continued", get_index());
             resume_requested = false;
@@ -283,6 +283,7 @@ bool runner::wait_for_init(const unsigned long& interval) {
 
 void runner::suspend() {
     suspend_mutex.lock();
+    resume_requested = false;
     if (get_process_status() == process_still_active) {
         int err = kill(proc_pid, SIGSTOP);
         LOG("suspend", get_index(), err);
@@ -292,8 +293,8 @@ void runner::suspend() {
 
 void runner::resume() {
     suspend_mutex.lock();
+    resume_requested = true;
     if (get_process_status() == process_suspended) {
-        resume_requested = true;
         int err = kill(proc_pid, SIGCONT);
         LOG("resume", get_index(), err);
     }


### PR DESCRIPTION
Рассмотрим функции suspend, resume класса runner.
Обе функции посылают сигналы "SIGSTOP" и "SIGCONT", если "process_status" равен "process_still_active" и "process_suspended" соответственно.
До того как сигнал будет обработан и состояние process_status изменится на новое, может произойти несколько вызовов suspend/resume.
Для запоминания этого используется переменная "resume_requested".
Если после вызова "suspend" произошел вызов "resume", то после срабатывания обработчика "suspend" выполнится
if (resume_requested) { resume(); }
Если после вызова "resume" происходит вызов "suspend", необходимо обнулять переменную "resume_requested".

Смену состояния
"process_status = process_suspended;"
в методе runner::waitpid_body, необходимо делать до вызова функции resume(), так как в ней происходит проверка
if (get_process_status() == process_suspended)
    kill(proc_pid, SIGCONT);